### PR TITLE
Missed axi case and system verilog translation error

### DIFF
--- a/src/spi2axi.sv
+++ b/src/spi2axi.sv
@@ -1,3 +1,4 @@
+`timescale 1ns / 1ps
 //--------------------------------------------------------------------------------------------------
 //
 //  SPI to AXI4-Lite Bridge
@@ -162,16 +163,15 @@ module spi2axi #( // @suppress "File contains multiple design units"
     //----------------------------------------------------------------------------------------------
     // SPI receive/transmit state machine
     //----------------------------------------------------------------------------------------------
+    logic [2:0] spi_rx_bit_idx = 0;
+    logic [$clog2(SPI_FRAME_LENGTH_BYTES):0] spi_rx_byte_idx = 0;
+    logic [2:0] spi_tx_bit_idx = 0;
+    logic [$clog2(SPI_FRAME_LENGTH_BYTES):0] spi_tx_byte_idx = 0;
+    logic spi_sck_re;
+    logic spi_sck_fe;
+    logic [7:0] spi_tx_byte;
 
-    always_ff@(posedge axi_aclk) begin: spi_fsm
-        logic [2:0] spi_rx_bit_idx = 0;
-        logic [$clog2(SPI_FRAME_LENGTH_BYTES):0] spi_rx_byte_idx = 0;
-        logic [2:0] spi_tx_bit_idx = 0;
-        logic [$clog2(SPI_FRAME_LENGTH_BYTES):0] spi_tx_byte_idx = 0;
-        logic spi_sck_re;
-        logic spi_sck_fe;
-        logic [2:0] spi_tx_byte;
-
+    always_ff@(posedge axi_aclk) begin: spi_fsm   
         if (~axi_aresetn) begin
             spi_rx_bit_idx   = 0;
             spi_rx_byte_idx  = 0;
@@ -265,10 +265,12 @@ module spi2axi #( // @suppress "File contains multiple design units"
                     end else begin
                         if (spi_rx_cmd == CMD_WRITE) begin
                             if (spi_rx_byte_idx <= 4) begin
-                                spi_rx_addr <= spi_rx_addr[23:0] & spi_rx_shreg;
+
+                                spi_rx_addr <={ spi_rx_addr[23:0], spi_rx_shreg };
+
                             end else if (spi_rx_byte_idx <= 8) begin
-                                spi_rx_wdata <= spi_rx_wdata[23:0] & spi_rx_shreg;
-                                //
+                                spi_rx_wdata <= { spi_rx_wdata[23:0], spi_rx_shreg };
+
                                 if (spi_rx_byte_idx == 8) begin
                                     // Write data complete -> trigger the AXI write access 
                                     spi_rx_valid <= 1'b1;

--- a/src/spi2axi.sv
+++ b/src/spi2axi.sv
@@ -402,22 +402,32 @@ module spi2axi #( // @suppress "File contains multiple design units"
                 // AXI write: wait for write address and data acknowledge
                 //------------------------------------------------------------------------------
                 AXI_WRITE_ACK : begin
-                    if (s_axi_awready == 1'b1) begin
-                        s_axi_awvalid_int <= 1'b0;
-                        //
-                        if (s_axi_wvalid_int == 1'b0) begin
-                            s_axi_bready_int <= 1'b1;
-                            axi_state    <= AXI_WRITE_BRESP; // move on when both write address and data have been acknowledged
+                    if (s_axi_awready == 1'b1 && s_axi_wready == 1'b1) begin
+                         s_axi_awvalid_int <= 1'b0;
+                         s_axi_wvalid_int <= 1'b0;
+                         s_axi_wstrb_int      <= '0;
+                         
+                         s_axi_bready_int <= 1'b1;
+                         axi_state    <= AXI_WRITE_BRESP; // move on when both write address and data have been acknowledged
+                    end 
+                    else begin
+                        if (s_axi_awready == 1'b1) begin
+                            s_axi_awvalid_int <= 1'b0;
+                            //
+                            if (s_axi_wvalid_int == 1'b0) begin
+                                s_axi_bready_int <= 1'b1;
+                                axi_state    <= AXI_WRITE_BRESP; // move on when both write address and data have been acknowledged
+                            end
                         end
-                    end
-                    //
-                    if (s_axi_wready == 1'b1) begin
-                        s_axi_wvalid_int <= 1'b0;
-                        s_axi_wstrb_int      <= '0;
                         //
-                        if (s_axi_awvalid_int == 1'b0) begin
-                            s_axi_bready_int <= 1'b1;
-                            axi_state    <= AXI_WRITE_BRESP; // move on when both write address and data have been acknowledged
+                        if (s_axi_wready == 1'b1) begin
+                            s_axi_wvalid_int <= 1'b0;
+                            s_axi_wstrb_int      <= '0;
+                            //
+                            if (s_axi_awvalid_int == 1'b0) begin
+                                s_axi_bready_int <= 1'b1;
+                                axi_state    <= AXI_WRITE_BRESP; // move on when both write address and data have been acknowledged
+                            end
                         end
                     end
                 end

--- a/src/spi2axi.vhd
+++ b/src/spi2axi.vhd
@@ -421,25 +421,33 @@ begin
                     -- AXI write: wait for write address and data acknowledge
                     --------------------------------------------------------------------------------
                     when AXI_WRITE_ACK =>
-                        if s_axi_awready = '1' then
+                        if s_axi_awready = '1' and s_axi_wready = '1' then
                             s_axi_awvalid_int <= '0';
-                            --
-                            if s_axi_wvalid_int = '0' then
-                                s_axi_bready <= '1';
-                                axi_state    <= AXI_WRITE_BRESP; -- move on when both write address and data have been acknowledged
-                            end if;
-                        end if;
-                        --
-                        if s_axi_wready = '1' then
                             s_axi_wvalid_int <= '0';
                             s_axi_wstrb      <= (others => '0');
+                            
+                             s_axi_bready <= '1';
+                             axi_state    <= AXI_WRITE_BRESP; -- move on when both write address and data have been acknowledged
+                        else
+                            if s_axi_awready = '1' then
+                                s_axi_awvalid_int <= '0';
+                                --
+                                if s_axi_wvalid_int = '0' then
+                                    s_axi_bready <= '1';
+                                    axi_state    <= AXI_WRITE_BRESP; -- move on when both write address and data have been acknowledged
+                                end if;
+                            end if;
                             --
-                            if s_axi_awvalid_int = '0' then
-                                s_axi_bready <= '1';
-                                axi_state    <= AXI_WRITE_BRESP; -- move on when both write address and data have been acknowledged
+                            if s_axi_wready = '1' then
+                                s_axi_wvalid_int <= '0';
+                                s_axi_wstrb      <= (others => '0');
+                                --
+                                if s_axi_awvalid_int = '0' then
+                                    s_axi_bready <= '1';
+                                    axi_state    <= AXI_WRITE_BRESP; -- move on when both write address and data have been acknowledged
+                                end if;
                             end if;
                         end if;
-
                     --------------------------------------------------------------------------------
                     -- AXI write: wait for write response
                     --------------------------------------------------------------------------------


### PR DESCRIPTION
AXI_WRITE_ACK bug commit - Noticed an issue where the AXI state machine would get stuck when both waready and wready (address and data) acknowledges went high at the same time. This is fixed by introducing a case to go to the next state when this occurs. 
SV incorrect translation; bit width bug commit - In translating the vhdl file, syntax was missed that caused incorrect data when reading in bytes. This line `spi_rx_addr <= spi_rx_addr[23:0] & spi_rx_shreg;` concatenates in VHDL and is a bitwise and in System Verilog. This caused the byte to be overwritten instead of added to. Additionally the variables being on the inside of the always block (line 166) caused them to not increment properly because they acted as local variables. Pulling them to the outside fixed this problem. Lastly, spi_tx_byte in that group had an incorrect bitwidth of [2:0] and was fixed to match the VHDL's [7:0]